### PR TITLE
Fix: Revert insurance plans to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@ FACEBOOK: https://www.facebook.com/themefisher
                 </a>
               </div>
               <div class="image-content text-center">
-                <span></span>
+                <span>Affordable Plans</span>
                 <a href="service.html">
                   <h6>Bronze Plan</h6>
                 </a>
@@ -454,7 +454,7 @@ FACEBOOK: https://www.facebook.com/themefisher
                 </a>
               </div>
               <div class="image-content text-center">
-                <span></span>
+                <span>Comprehensive Coverage</span>
                 <a href="service.html">
                   <h6>Silver Plan</h6>
                 </a>
@@ -470,7 +470,7 @@ FACEBOOK: https://www.facebook.com/themefisher
                 </a>
               </div>
               <div class="image-content text-center">
-                <span></span>
+                <span>Customizable Options</span>
                 <a href="service.html">
                   <h6>Gold Plan</h6>
                 </a>

--- a/service.html
+++ b/service.html
@@ -214,36 +214,36 @@ FACEBOOK: https://www.facebook.com/themefisher
       <div class="col-lg-12">
         <div class="contents">
           <div class="section-title">
-            <h3 style="text-align: center;">الخطة البرونزية</h3>
+            <h3 style="text-align: center;">Bronze Plan</h3>
           </div>
-          <table class="table" dir="rtl">
+          <table class="table">
             <thead>
               <tr>
-                <th>المنافع لكل مستفيد (بالدولار الأمريكي)</th>
-                <th>التغطية</th>
+                <th>Benefits per Beneficiary (in USD)</th>
+                <th>Coverage</th>
               </tr>
             </thead>
             <tbody>
-              <tr><td>النفقات الطبية المتكبدة أثناء الاستشفاء</td><td>$50,000</td></tr>
-              <tr><td>النفقات الطبية (المتعلقة بـ كوفيد-19)</td><td>$25,000</td></tr>
-              <tr><td>الإجلاء الطبي الطارئ</td><td>$500,000</td></tr>
-              <tr><td>إعادة طبية طارئة إلى الوطن</td><td>$500,000</td></tr>
-              <tr><td>نقل رفات الموتى</td><td>$10,000</td></tr>
-              <tr><td>زيارة رحيمة</td><td>$5,000</td></tr>
-              <tr><td>عودة الأطفال القصر</td><td>$5,000</td></tr>
-              <tr><td>مصاريف النقاهة</td><td>$500</td></tr>
-              <tr><td>طوارئ الأسنان بسبب حادث</td><td>$15,000</td></tr>
-              <tr><td>إنقاذ بحري وجبلي</td><td>$150</td></tr>
-              <tr><td>مصاريف الحجر الصحي (تصل إلى 10 أيام)</td><td>$50/يوم</td></tr>
-              <tr><td>فقدان جواز السفر</td><td>$0</td></tr>
-              <tr><td>تأخير الأمتعة (بعد 12 ساعة)</td><td>$0</td></tr>
-              <tr><td>فقدان الأمتعة (حتى 20 كجم) (بعد 21 يومًا)</td><td>$75</td></tr>
-              <tr><td>تأخير الرحلة (على الأقل 6 ساعات)</td><td>$2,000</td></tr>
-              <tr><td>إلغاء الرحلة (حتى 70 عامًا)</td><td>$125</td></tr>
-              <tr><td>تقليص الرحلة</td><td>$50</td></tr>
-              <tr><td>تغييرات في التذكرة/رحلة مؤجلة</td><td>$250</td></tr>
-              <tr><td>الوفاة بحادث</td><td>$25,000</td></tr>
-              <tr><td>المساعدة الطبية والسفر</td><td>خدمة مجانية</td></tr>
+              <tr><td>Medical expenses incurred during hospitalization</td><td>$50,000</td></tr>
+              <tr><td>Medical expenses (Related to Covid-19)</td><td>$25,000</td></tr>
+              <tr><td>Emergency medical evacuation</td><td>$500,000</td></tr>
+              <tr><td>Emergency medical repatriation</td><td>$500,000</td></tr>
+              <tr><td>Transportation of mortal remains</td><td>$10,000</td></tr>
+              <tr><td>Compassionate visit</td><td>$5,000</td></tr>
+              <tr><td>Return of minor children</td><td>$5,000</td></tr>
+              <tr><td>Convalescence expenses</td><td>$500</td></tr>
+              <tr><td>Dental emergency due to accident</td><td>$15,000</td></tr>
+              <tr><td>Sea & Mountain Rescue</td><td>$150</td></tr>
+              <tr><td>Quarantine Expenses (up to 10 days)</td><td>$50/day</td></tr>
+              <tr><td>Loss of Passport</td><td>$0</td></tr>
+              <tr><td>Luggage Delay (after 12 hours)</td><td>$0</td></tr>
+              <tr><td>Luggage Loss (up to 20 Kg) (after 21 days)</td><td>$75</td></tr>
+              <tr><td>Flight Delay (at least 6 hours)</td><td>$2,000</td></tr>
+              <tr><td>Trip Cancellation (up to 70 years old)</td><td>$125</td></tr>
+              <tr><td>Trip Curtailment</td><td>$50</td></tr>
+              <tr><td>Changes in Ticket/Postponed Flight</td><td>$250</td></tr>
+              <tr><td>Death due to accident</td><td>$25,000</td></tr>
+              <tr><td>Medical & Travel Assistance</td><td>Free Service</td></tr>
             </tbody>
           </table>
         </div>
@@ -254,39 +254,39 @@ FACEBOOK: https://www.facebook.com/themefisher
       <div class="col-lg-12">
         <div class="contents">
           <div class="section-title">
-            <h3 style="text-align: center;">الخطة الفضية</h3>
+            <h3 style="text-align: center;">Silver Plan</h3>
           </div>
-          <table class="table" dir="rtl">
+          <table class="table">
             <thead>
                 <tr>
-                    <th>المنافع لكل مستفيد (بالدولار الأمريكي)</th>
-                    <th>التغطية</th>
+                    <th>Benefits per Beneficiary (in USD)</th>
+                    <th>Coverage</th>
                 </tr>
             </thead>
             <tbody>
-                <tr><td>منطقة التغطية</td><td>حول العالم</td></tr>
-                <tr><td>فترة التغطية</td><td>365 يومًا</td></tr>
-                <tr><td>تاريخ انتهاء الصلاحية</td><td>21/02/2026</td></tr>
-                <tr><td>النفقات الطبية المتكبدة أثناء الاستشفاء</td><td>$100,000</td></tr>
-                <tr><td>النفقات الطبية (المتعلقة بـ كوفيد-19)</td><td>$50,000</td></tr>
-                <tr><td>الإجلاء الطبي الطارئ</td><td>$1,000,000</td></tr>
-                <tr><td>إعادة طبية طارئة إلى الوطن</td><td>$1,000,000</td></tr>
-                <tr><td>نقل رفات الموتى</td><td>$20,000</td></tr>
-                <tr><td>زيارة رحيمة</td><td>$10,000</td></tr>
-                <tr><td>عودة الأطفال القصر</td><td>$10,000</td></tr>
-                <tr><td>مصاريف النقاهة</td><td>$1,000</td></tr>
-                <tr><td>طوارئ الأسنان بسبب حادث</td><td>$25,000</td></tr>
-                <tr><td>إنقاذ بحري وجبلي</td><td>$300</td></tr>
-                <tr><td>مصاريف الحجر الصحي (تصل إلى 14 يومًا)</td><td>$70/يوم</td></tr>
-                <tr><td>فقدان جواز السفر</td><td>$300</td></tr>
-                <tr><td>تأخير الأمتعة (بعد 12 ساعة)</td><td>$20</td></tr>
-                <tr><td>فقدان الأمتعة (حتى 40 كجم) (بعد 21 يومًا)</td><td>$150</td></tr>
-                <tr><td>تأخير الرحلة (على الأقل 4 ساعات)</td><td>$4,000</td></tr>
-                <tr><td>إلغاء الرحلة (حتى 70 عامًا)</td><td>$250</td></tr>
-                <tr><td>تقليص الرحلة</td><td>$100</td></tr>
-                <tr><td>تغييرات في التذكرة/رحلة مؤجلة</td><td>$500</td></tr>
-                <tr><td>الوفاة بحادث</td><td>$50,000</td></tr>
-                <tr><td>المساعدة الطبية والسفر</td><td>خدمة مجانية</td></tr>
+                <tr><td>COVERAGE ZONE</td><td>Worldwide</td></tr>
+                <tr><td>PERIOD OF COVERAGE</td><td>365 Days</td></tr>
+                <tr><td>EXPIRY DATE</td><td>21/02/2026</td></tr>
+                <tr><td>Medical expenses incurred during hospitalization</td><td>$100,000</td></tr>
+                <tr><td>Medical expenses (Related to Covid-19)</td><td>$50,000</td></tr>
+                <tr><td>Emergency medical evacuation</td><td>$1,000,000</td></tr>
+                <tr><td>Emergency medical repatriation</td><td>$1,000,000</td></tr>
+                <tr><td>Transportation of mortal remains</td><td>$20,000</td></tr>
+                <tr><td>Compassionate visit</td><td>$10,000</td></tr>
+                <tr><td>Return of minor children</td><td>$10,000</td></tr>
+                <tr><td>Convalescence expenses</td><td>$1,000</td></tr>
+                <tr><td>Dental emergency due to accident</td><td>$25,000</td></tr>
+                <tr><td>Sea & Mountain Rescue</td><td>$300</td></tr>
+                <tr><td>Quarantine Expenses (up to 14 days)</td><td>$70/day</td></tr>
+                <tr><td>Loss of Passport</td><td>$300</td></tr>
+                <tr><td>Luggage Delay (after 12 hours)</td><td>$20</td></tr>
+                <tr><td>Luggage Loss (up to 40 Kg) (after 21 days)</td><td>$150</td></tr>
+                <tr><td>Flight Delay (at least 4 hours)</td><td>$4,000</td></tr>
+                <tr><td>Trip Cancellation (up to 70 years old)</td><td>$250</td></tr>
+                <tr><td>Trip Curtailment</td><td>$100</td></tr>
+                <tr><td>Changes in Ticket/Postponed Flight</td><td>$500</td></tr>
+                <tr><td>Death due to accident</td><td>$50,000</td></tr>
+                <tr><td>Medical & Travel Assistance</td><td>Free Service</td></tr>
             </tbody>
           </table>
         </div>
@@ -297,36 +297,36 @@ FACEBOOK: https://www.facebook.com/themefisher
       <div class="col-lg-12">
         <div class="contents">
           <div class="section-title">
-            <h3 style="text-align: center;">الخطة الذهبية</h3>
+            <h3 style="text-align: center;">Gold Plan</h3>
           </div>
-          <table class="table" dir="rtl">
+          <table class="table">
             <thead>
               <tr>
-                <th>المنافع لكل مستفيد (بالدولار الأمريكي)</th>
-                <th>التغطية</th>
+                <th>Benefits per Beneficiary (in USD)</th>
+                <th>Coverage</th>
               </tr>
             </thead>
             <tbody>
-              <tr><td>النفقات الطبية المتكبدة أثناء الاستشفاء</td><td>$200,000</td></tr>
-              <tr><td>النفقات الطبية (المتعلقة بـ كوفيد-19)</td><td>$100,000</td></tr>
-              <tr><td>الإجلاء الطبي الطارئ</td><td>$2,000,000</td></tr>
-              <tr><td>إعادة طبية طارئة إلى الوطن</td><td>$2,000,000</td></tr>
-              <tr><td>نقل رفات الموتى</td><td>$40,000</td></tr>
-              <tr><td>زيارة رحيمة</td><td>$20,000</td></tr>
-              <tr><td>عودة الأطفال القصر</td><td>$20,000</td></tr>
-              <tr><td>مصاريف النقاهة</td><td>$2,000</td></tr>
-              <tr><td>طوارئ الأسنان بسبب حادث</td><td>$50,000</td></tr>
-              <tr><td>إنقاذ بحري وجبلي</td><td>$600</td></tr>
-              <tr><td>مصاريف الحجر الصحي (تصل إلى 21 يومًا)</td><td>$100/يوم</td></tr>
-              <tr><td>فقدان جواز السفر</td><td>$600</td></tr>
-              <tr><td>تأخير الأمتعة (بعد 6 ساعات)</td><td>$40</td></tr>
-              <tr><td>فقدان الأمتعة (حتى 50 كجم) (بعد 14 يومًا)</td><td>$300</td></tr>
-              <tr><td>تأخير الرحلة (على الأقل ساعتان)</td><td>$8,000</td></tr>
-              <tr><td>إلغاء الرحلة (حتى 80 عامًا)</td><td>$500</td></tr>
-              <tr><td>تقليص الرحلة</td><td>$200</td></tr>
-              <tr><td>تغييرات في التذكرة/رحلة مؤجلة</td><td>$1,000</td></tr>
-              <tr><td>الوفاة بحادث</td><td>$100,000</td></tr>
-              <tr><td>المساعدة الطبية والسفر</td><td>خدمة مجانية</td></tr>
+              <tr><td>Medical expenses incurred during hospitalization</td><td>$200,000</td></tr>
+              <tr><td>Medical expenses (Related to Covid-19)</td><td>$100,000</td></tr>
+              <tr><td>Emergency medical evacuation</td><td>$2,000,000</td></tr>
+              <tr><td>Emergency medical repatriation</td><td>$2,000,000</td></tr>
+              <tr><td>Transportation of mortal remains</td><td>$40,000</td></tr>
+              <tr><td>Compassionate visit</td><td>$20,000</td></tr>
+              <tr><td>Return of minor children</td><td>$20,000</td></tr>
+              <tr><td>Convalescence expenses</td><td>$2,000</td></tr>
+              <tr><td>Dental emergency due to accident</td><td>$50,000</td></tr>
+              <tr><td>Sea & Mountain Rescue</td><td>$600</td></tr>
+              <tr><td>Quarantine Expenses (up to 21 days)</td><td>$100/day</td></tr>
+              <tr><td>Loss of Passport</td><td>$600</td></tr>
+              <tr><td>Luggage Delay (after 6 hours)</td><td>$40</td></tr>
+              <tr><td>Luggage Loss (up to 50 Kg) (after 14 days)</td><td>$300</td></tr>
+              <tr><td>Flight Delay (at least 2 hours)</td><td>$8,000</td></tr>
+              <tr><td>Trip Cancellation (up to 80 years old)</td><td>$500</td></tr>
+              <tr><td>Trip Curtailment</td><td>$200</td></tr>
+              <tr><td>Changes in Ticket/Postponed Flight</td><td>$1,000</td></tr>
+              <tr><td>Death due to accident</td><td>$100,000</td></tr>
+              <tr><td>Medical & Travel Assistance</td><td>Free Service</td></tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
This reverts the previous changes that translated the insurance plans to Arabic. The user requested the content to be in English.

- Reverted plan details in `service.html` to English.
- Reverted plan names in `index.html` to English.